### PR TITLE
added image url to embed description on avatar command

### DIFF
--- a/cogs/commands/misc/misc.py
+++ b/cogs/commands/misc/misc.py
@@ -123,7 +123,7 @@ class Misc(commands.Cog):
             member = ctx.author
 
         await ctx.message.delete()
-        embed = discord.Embed(title=f"{member}'s avatar")
+        embed = discord.Embed(title=f"{member}'s avatar", description=member.avatar_url)
         embed.set_image(url=member.avatar_url)
         embed.color = discord.Color.random()
         embed.set_footer(text=f"Requested by {ctx.author}")


### PR DESCRIPTION
This makes it easy for people to embed the avatar link in certain situations, instead of clicking on the image, "open original" and copying the URL. I set this on initialisation [as stated in the documentation[(https://discordpy.readthedocs.io/en/stable/api.html?highlight=embed#discord.Embed.url). I haven't tested the code but it's a very simple change and I don't see why it wouldn't work