### PR TITLE
'!ping' command updates

### DIFF
--- a/cogs/commands/info/stats.py
+++ b/cogs/commands/info/stats.py
@@ -55,7 +55,7 @@ class Stats(commands.Cog):
         """
 
         embed = discord.Embed(
-            title=f"Pong!", color=discord.Color.blurple())
+            title="Pong!", color=discord.Color.blurple())
         embed.set_thumbnail(url=self.bot.user.avatar_url)
         embed.description = "Latency: testing..."
 

--- a/cogs/commands/info/stats.py
+++ b/cogs/commands/info/stats.py
@@ -54,13 +54,13 @@ class Stats(commands.Cog):
 
         """
 
-        b = datetime.datetime.utcnow()
         embed = discord.Embed(
             title=f"Pong!", color=discord.Color.blurple())
         embed.set_thumbnail(url=self.bot.user.avatar_url)
         embed.description = "Latency: testing..."
 
         # measure time between sending a message and time it is posted
+        b = datetime.datetime.utcnow()
         m = await ctx.message.reply(embed=embed)
         ping = floor((datetime.datetime.utcnow() - b).total_seconds() * 1000)
         await sleep(1)

--- a/cogs/commands/info/stats.py
+++ b/cogs/commands/info/stats.py
@@ -64,7 +64,7 @@ class Stats(commands.Cog):
         m = await ctx.message.reply(embed=embed)
         ping = floor((datetime.datetime.utcnow() - b).total_seconds() * 1000)
         await sleep(1)
-        embed.description = f"Latency: {ping} ms"
+        embed.description = f"Latency: `{ping}ms`"
         await m.edit(embed=embed)
 
     @commands.guild_only()


### PR DESCRIPTION
This PR:
- Removes the creation of the message's embed from the latency measurement
- Wraps the latency in a code block when it edits the message
- Changes the embed's title from an f-string to a string

In my testing, this reduced the latency measurement by about ~`300ms` while hosting locally.