### PR TITLE
Correctly show paid packages and view the package's depiction if available

### DIFF
--- a/cogs/commands/misc/parcility.py
+++ b/cogs/commands/misc/parcility.py
@@ -70,7 +70,6 @@ class TweakMenu(menus.AsyncIteratorPageSource):
         try:
             embed.add_field(name="More Info", value=f"[View Depiction]({entry.get('Depiction')})", inline=False)
         except:
-            #embed.add_field(name="More Info", value=f"[View on Parcility]({'https://parcility.co/package/'+object['Package']+'/'+object['repo']['slug']})", inline=False) 
             embed.add_field(name="More Info", value=f"[View on Parcility](https://parcility.co/package/{entry.get('Package')}/{entry.get('repo').get('slug')})", inline=False)
         pattern = re.compile(r"((http|https)\:\/\/)[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*")
         if (pattern.match(entry.get('Icon'))):

--- a/cogs/commands/misc/parcility.py
+++ b/cogs/commands/misc/parcility.py
@@ -68,7 +68,10 @@ class TweakMenu(menus.AsyncIteratorPageSource):
         if entry.get('repo').get('isDefault') is False:
             embed.add_field(name="Add Repo", value=f"[Click Here](https://sharerepo.stkc.win/?repo={entry.get('repo').get('url')})" or "No repo", inline=True)
         try:
-            embed.add_field(name="More Info", value=f"[View Depiction]({entry.get('Depiction')})", inline=False)
+            if entry.get('Depiction'):
+                embed.add_field(name="More Info", value=f"[View Depiction]({entry.get('Depiction')})", inline=False)
+            else:
+                raise Exception("No depiction found!")
         except:
             embed.add_field(name="More Info", value=f"[View on Parcility](https://parcility.co/package/{entry.get('Package')}/{entry.get('repo').get('slug')})", inline=False)
         pattern = re.compile(r"((http|https)\:\/\/)[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*")

--- a/cogs/commands/misc/parcility.py
+++ b/cogs/commands/misc/parcility.py
@@ -63,11 +63,15 @@ class TweakMenu(menus.AsyncIteratorPageSource):
         embed.description = discord.utils.escape_markdown(entry.get('Description')) or "No description"
         embed.add_field(name="Author", value= discord.utils.escape_markdown(entry.get('Author') or "No author"), inline=True)
         embed.add_field(name="Version", value= discord.utils.escape_markdown(entry.get('Version') or "No version"), inline=True)
-        embed.add_field(name="Price", value=entry.get("Price") or "Free")
+        embed.add_field(name="Price", value=entry.get("Price") or (entry.get("Tag") and "cydia::commercial" in entry.get("Tag") and "Paid") or "Free")
         embed.add_field(name="Repo", value=f"[{entry.get('repo').get('label')}]({entry.get('repo').get('url')})" or "No repo", inline=True)
         if entry.get('repo').get('isDefault') is False:
             embed.add_field(name="Add Repo", value=f"[Click Here](https://sharerepo.stkc.win/?repo={entry.get('repo').get('url')})" or "No repo", inline=True)
-        embed.add_field(name="More Info", value=f"[View on Parcility](https://parcility.co/package/{entry.get('Package')}/{entry.get('repo').get('slug')})", inline=False)
+        try:
+            embed.add_field(name="More Info", value=f"[View Depiction]({entry.get('Depiction')})", inline=False)
+        except:
+            #embed.add_field(name="More Info", value=f"[View on Parcility]({'https://parcility.co/package/'+object['Package']+'/'+object['repo']['slug']})", inline=False) 
+            embed.add_field(name="More Info", value=f"[View on Parcility](https://parcility.co/package/{entry.get('Package')}/{entry.get('repo').get('slug')})", inline=False)
         pattern = re.compile(r"((http|https)\:\/\/)[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*")
         if (pattern.match(entry.get('Icon'))):
             embed.set_thumbnail(url=entry.get('Icon'))


### PR DESCRIPTION
- If the `Price` attribute isn't available (Packix moment), check for the tag `cydia::commercial` and return a blanket "Paid" if it exists
- (@stekc but he's a lazy ass and asked me to pr instead) View the package's depiction if it is available, and use Parcility only as a fallback.

[Paid packages are now paid + view depiction](https://user-images.githubusercontent.com/92439990/141261639-7c5b946d-5254-4883-937c-e9de021cfd3d.png)
[Falling back to View on Parcility if there's no depiction](https://user-images.githubusercontent.com/92439990/141261723-0fb1c94d-3158-42bb-8296-ff23ad42c5ba.png)
![lazy stkc](https://user-images.githubusercontent.com/92439990/141261971-d57d773d-5e8b-4233-a469-4e76e7e624eb.png)


